### PR TITLE
Update agent.py

### DIFF
--- a/commands/agent.py
+++ b/commands/agent.py
@@ -1068,10 +1068,10 @@ class AgentRunner:
                     line = f"• [{nid}] {lbl} ({typ})"
                     annotations = []
                     if observations:
-                        obs_str = '; '.join(observations[:-3])
+                        obs_str = '; '.join(observations[-3:])
                         annotations.append(f"obs:{obs_str}")
                     if assumptions:
-                        assum_str = '; '.join(assumptions[:-3])
+                        assum_str = '; '.join(assumptions[-3:])
                         annotations.append(f"asm:{assum_str}")
                     if annotations:
                         line += f" [{' | '.join(annotations)}]"


### PR DESCRIPTION
Subject: Discrepancy in _graph_summary Function Output

Each call to the _graph_summary function is not intended to display the three most recent observations and assumptions.

Reasoning:

1. The _graph_summary function reads the current node data from self.agent.loaded_data every time it is called.

2. When update_node is invoked, it uses the append() method to add new observations/assumptions to the end of the node's list.

3. Because Python lists are ordered, newly added items appear at the very end of the list.

4. The code uses the slice observations[:3], which retrieves the first three elements from the list, not the last three.

Important Finding:
The function is actually displaying the oldest three entries, not the most recent ones. To display the latest three items, the code should be observations[-3:].

security impact: medium