### PR TITLE
graph build: stop reporting completion on failed iterations; fix forced-graph loop

### DIFF
--- a/analysis/graph_builder.py
+++ b/analysis/graph_builder.py
@@ -416,6 +416,7 @@ class GraphBuilder:
             self._discover_graphs(manifest, cards, focus_areas, max_graphs, force_graphs)
         
         # Phase 2: Iterative Graph Building
+        self._build_had_failures = False
         if self.debug:
             print("\n[Phase 2] Iterative Graph Building")
         for i in range(max_iterations):
@@ -425,10 +426,13 @@ class GraphBuilder:
             self._emit("building", f"Building graphs: iteration {i+1}/{max_iterations}")
             
             # Build/refine graphs with early stopping if complete
-            had_updates = self._build_iteration(cards)
-            
-            # Early exit if no graphs were updated (all complete)
-            if not had_updates and i > 0:  # Allow at least 2 iterations
+            had_updates, had_failures = self._build_iteration(cards)
+            if had_failures:
+                self._build_had_failures = True
+
+            # Early exit only if nothing was updated AND nothing failed: a
+            # failure-only pass must not be mistaken for completion.
+            if not had_updates and not had_failures and i > 0:  # Allow at least 2 iterations
                 self._emit("early_exit", f"All graphs complete after {i+1} iterations")
                 if self.debug:
                     print(f"  Early exit: All graphs complete after {i+1} iterations")
@@ -437,7 +441,12 @@ class GraphBuilder:
         # Phase 3: Save results
         self._emit("phase", "Saving Results")
         results = self._save_results(output_dir, manifest)
-        
+        if isinstance(results, dict):
+            results["had_failures"] = bool(getattr(self, "_build_had_failures", False))
+        if getattr(self, "_build_had_failures", False):
+            self._emit("warn", "Some graph-building LLM calls failed; the graph may be INCOMPLETE. "
+                               "Re-run with --debug for details, and consider `graph rm --all` then rebuild.")
+
         duration = time.time() - start_time
         self._emit("complete", f"Complete in {duration:.1f}s")
         
@@ -459,18 +468,18 @@ class GraphBuilder:
             for graph_spec in force_graphs:
                 name = graph_spec["name"].replace(' ', '_').replace('/', '_')
                 focus = graph_spec["focus"]
-            self.graphs[name] = KnowledgeGraph(
-                name=name,
-                focus=focus,
-                metadata={"created_at": time.time(), "display_name": graph_spec["name"]}
-            )
-            self._emit("graph", f"Created graph: {graph_spec['name']} (focus: {focus})")
-            # Save initial empty graph immediately
-            try:
-                self._save_graph(output_dir=self._output_dir, graph=self.graphs[name])
-                self._emit("save", f"Saved schema for {name}")
-            except Exception:
-                pass
+                self.graphs[name] = KnowledgeGraph(
+                    name=name,
+                    focus=focus,
+                    metadata={"created_at": time.time(), "display_name": graph_spec["name"]}
+                )
+                self._emit("graph", f"Created graph: {graph_spec['name']} (focus: {focus})")
+                # Save initial empty graph immediately
+                try:
+                    self._save_graph(output_dir=self._output_dir, graph=self.graphs[name])
+                    self._emit("save", f"Saved schema for {name}")
+                except Exception:
+                    pass
             return
         
         # Use adaptive sampling based on token count for discovery phase
@@ -606,10 +615,12 @@ The FIRST must be the system/component/flow overview."""
         if discovery.suggested_edge_types:
             self._emit("note", f"Custom edge types: {', '.join(discovery.suggested_edge_types)}")
     
-    def _build_iteration(self, cards: list[dict]) -> bool:
+    def _build_iteration(self, cards: list[dict]) -> tuple[bool, bool]:
         """
         Single iteration to build/refine graphs.
-        Returns True if any graph was updated, False if all graphs are complete.
+        Returns (any_updates, had_failures): any_updates is True if any graph
+        gained nodes/edges; had_failures is True if any per-graph update call
+        failed, so the caller must not treat this pass as completion.
         """
         
         any_updates = False
@@ -650,10 +661,10 @@ The FIRST must be the system/component/flow overview."""
             else:
                 had_failures = True
         
-        # Don't allow early-exit logic in caller to treat an error-only pass as completion
+        # Propagate had_failures so the caller does not treat an error-only pass as completion.
         if had_failures and self.debug:
             print("  One or more update calls failed this iteration; skipping early completion heuristics.")
-        return any_updates
+        return any_updates, had_failures
     
     def _get_orphaned_nodes(self, graph: KnowledgeGraph) -> set:
         """Find nodes with no edges (neither incoming nor outgoing)"""


### PR DESCRIPTION
Two small correctness fixes in `analysis/graph_builder.py`, both found while running audits on Solidity codebases. Each causes silent graph incompleteness, and the first looks like a concrete root cause behind #32 ("System architecture graphs may be incomplete").

## 1. A failed build iteration is reported as "complete"

`_build_iteration()` already detects per-graph update failures into `had_failures`, and there is even a comment saying the caller must not treat an error-only pass as completion — but the value is never returned (`return any_updates` drops it):

```python
            else:
                had_failures = True

        # Don't allow early-exit logic in caller to treat an error-only pass as completion
        if had_failures and self.debug:
            print("  One or more update calls failed this iteration; ...")
        return any_updates          # had_failures is dropped
```

The caller's only early-exit test is `not had_updates`:

```python
        had_updates = self._build_iteration(cards)
        # Early exit if no graphs were updated (all complete)
        if not had_updates and i > 0:
            self._emit("early_exit", f"All graphs complete after {i+1} iterations")
            break
```

So when an iteration's update calls all fail (`_update_graph` returns `None` after its retries, so `any_updates` stays `False`), `build()` breaks early and emits "All graphs complete", persisting a partial or empty graph. No exception, no non-zero exit.

**Impact:** a transient API/JSON error mid-build produces a silently incomplete graph that every subsequent `agent audit` treats as ground truth. It is hard to notice downstream because coverage is computed against the graph's own nodes (`coverage_index.py`, `session_tracker.py`), so components dropped during the build are not even counted as "uncovered" — an incomplete graph can still report ~100% node coverage (related: #27, #32).

**Fix:** propagate `had_failures` and only early-exit when a pass had no updates **and** no failures. Also surface it — emit a warning and record `had_failures` in `knowledge_graphs.json` so partial builds are detectable.

## 2. Multiple forced graphs collapse to one

In `_discover_graphs()`, the graph-creation block is dedented out of the `for graph_spec in force_graphs:` loop, so only the last spec's graph is ever created:

```python
        if force_graphs:
            for graph_spec in force_graphs:
                name = graph_spec["name"].replace(' ', '_').replace('/', '_')
                focus = graph_spec["focus"]
            self.graphs[name] = KnowledgeGraph(   # runs once, after the loop
                name=name, focus=focus, ...
            )
            ...
            return
```

Low blast radius today because the CLI passes a single forced graph, but it is a latent correctness bug and a dead loop. **Fix:** move creation inside the loop; return after all forced graphs are created.

## Testing

- `python -m py_compile analysis/graph_builder.py` passes; `_build_iteration` has a single caller, updated to the tuple return.
- Fix 1 is a local control-flow change; the early-exit branch now requires `not had_failures`, so an error-only iteration continues (allowing retries on later iterations) instead of terminating as "complete". To reproduce the original behavior, force `_update_graph` to raise on an iteration `i > 0` and observe the pre-fix "All graphs complete" with a partial graph.
- Fix 2 is verifiable by inspection, or a unit test calling `_discover_graphs` with two `force_graphs` entries (pre-fix: 1 graph; post-fix: 2).
