### PR TITLE
Feat/add litellm provider

### DIFF
--- a/llm/litellm_provider.py
+++ b/llm/litellm_provider.py
@@ -1,0 +1,181 @@
+"""LiteLLM provider implementation.
+
+LiteLLM (https://litellm.ai) provides a unified interface to 100+ LLM
+providers including OpenAI, Anthropic, Google, Azure, AWS Bedrock, and more.
+
+Models are specified using LiteLLM's provider/model format, e.g.:
+  - "anthropic/claude-sonnet-4-6"
+  - "azure/gpt-4o"
+  - "bedrock/anthropic.claude-3-haiku-20240307-v1:0"
+  - "vertex_ai/gemini-2.0-flash"
+
+Provider API keys are read from environment variables automatically by LiteLLM
+(e.g. ANTHROPIC_API_KEY, AZURE_API_KEY). No additional configuration is needed
+beyond setting the relevant env var for your chosen provider.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+import random
+import time
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from .base_provider import BaseLLMProvider
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class LiteLLMProvider(BaseLLMProvider):
+    """LiteLLM AI gateway provider implementation."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        model_name: str,
+        timeout: int = 120,
+        retries: int = 3,
+        backoff_min: float = 2.0,
+        backoff_max: float = 8.0,
+        reasoning_effort: str | None = None,
+        **kwargs
+    ):
+        """Initialize LiteLLM provider."""
+        self.config = config
+        self.model_name = model_name
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff_min = backoff_min
+        self.backoff_max = backoff_max
+        self.reasoning_effort = reasoning_effort
+        logging_cfg = config.get("logging", {}) if isinstance(config, dict) else {}
+        env_verbose = os.environ.get("HOUND_LLM_VERBOSE", "").lower() in {"1", "true", "yes", "on"}
+        self.verbose = bool(logging_cfg.get("llm_verbose", False) or env_verbose)
+        self._last_token_usage = None
+
+        litellm_cfg = config.get("litellm", {}) if isinstance(config, dict) else {}
+        api_key_env = litellm_cfg.get("api_key_env", "LITELLM_API_KEY")
+        self.api_key = os.environ.get(api_key_env) or None
+        self.api_base = litellm_cfg.get("api_base") or os.environ.get("LITELLM_API_BASE") or None
+
+    def _completion(self, messages: list[dict], **extra_kwargs) -> Any:
+        """Call litellm.completion with standard kwargs."""
+        import litellm
+
+        kwargs: dict[str, Any] = {
+            "model": self.model_name,
+            "messages": messages,
+            "timeout": self.timeout,
+            "drop_params": True,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        kwargs.update(extra_kwargs)
+        return litellm.completion(**kwargs)
+
+    def _store_usage(self, response: Any) -> None:
+        """Extract and store token usage from a litellm response."""
+        try:
+            usage = getattr(response, 'usage', None)
+            if usage:
+                self._last_token_usage = {
+                    'input_tokens': getattr(usage, 'prompt_tokens', 0) or 0,
+                    'output_tokens': getattr(usage, 'completion_tokens', 0) or 0,
+                    'total_tokens': getattr(usage, 'total_tokens', 0) or 0,
+                }
+        except Exception:
+            pass
+
+    def parse(self, *, system: str, user: str, schema: type[T], **kwargs) -> T:
+        """Make a structured call returning an instance of the schema."""
+        try:
+            json_schema = schema.model_json_schema()
+        except Exception:
+            json_schema = None
+
+        schema_hint = ""
+        if isinstance(json_schema, dict):
+            schema_hint = (
+                "\nRespond with valid JSON matching this schema exactly "
+                "(no extra keys, all required fields):\n"
+                + _json.dumps(json_schema)
+            )
+        json_instruction = schema_hint + "\nReturn ONLY valid JSON. No markdown. No prose."
+
+        messages = [
+            {"role": "system", "content": system + json_instruction},
+            {"role": "user", "content": user},
+        ]
+
+        request_chars = len(system) + len(user)
+        if self.verbose:
+            print("\n[LiteLLM Request]")
+            print(f"  Model: {self.model_name}")
+            print(f"  Schema: {schema.__name__}")
+            print(f"  Total prompt: {request_chars:,} chars (~{request_chars // 4:,} tokens)")
+
+        last_err = None
+        for attempt in range(self.retries):
+            try:
+                if self.verbose:
+                    print(f"  Attempt {attempt + 1}/{self.retries}...")
+
+                response = self._completion(
+                    messages,
+                    response_format={"type": "json_object"},
+                )
+                self._store_usage(response)
+                json_str = response.choices[0].message.content
+                return schema.model_validate_json(json_str)
+
+            except Exception as e:
+                last_err = e
+                if self.verbose:
+                    print(f"  Error: {e}")
+                if attempt < self.retries - 1:
+                    sleep_time = random.uniform(self.backoff_min, self.backoff_max)
+                    if self.verbose:
+                        print(f"  Retrying after {sleep_time:.2f}s...")
+                    time.sleep(sleep_time)
+
+        raise RuntimeError(f"LiteLLM call failed after {self.retries} attempts: {last_err}")
+
+    def raw(self, *, system: str, user: str, **kwargs) -> str:
+        """Make a plain text call without structured output."""
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+
+        last_err = None
+        for attempt in range(self.retries):
+            try:
+                response = self._completion(messages)
+                self._store_usage(response)
+                return response.choices[0].message.content
+
+            except Exception as e:
+                last_err = e
+                if attempt < self.retries - 1:
+                    sleep_time = random.uniform(self.backoff_min, self.backoff_max)
+                    time.sleep(sleep_time)
+
+        raise RuntimeError(f"LiteLLM raw call failed after {self.retries} attempts: {last_err}")
+
+    @property
+    def provider_name(self) -> str:
+        """Return provider name."""
+        return "LiteLLM"
+
+    @property
+    def supports_thinking(self) -> bool:
+        """LiteLLM delegates to the underlying provider; thinking support varies by model."""
+        return False
+
+    def get_last_token_usage(self) -> dict[str, int] | None:
+        """Return token usage from the last call if available."""
+        return self._last_token_usage

--- a/llm/litellm_provider.py
+++ b/llm/litellm_provider.py
@@ -28,6 +28,17 @@ from .base_provider import BaseLLMProvider
 T = TypeVar('T', bound=BaseModel)
 
 
+def _is_non_retryable(exc: BaseException) -> bool:
+    """Check if an exception should NOT be retried (auth errors, bad model, etc.)."""
+    qualname = f"{type(exc).__module__}.{type(exc).__qualname__}"
+    return qualname in {
+        "litellm.exceptions.AuthenticationError",
+        "litellm.exceptions.NotFoundError",
+        "litellm.exceptions.BadRequestError",
+        "litellm.exceptions.PermissionDeniedError",
+    }
+
+
 class LiteLLMProvider(BaseLLMProvider):
     """LiteLLM AI gateway provider implementation."""
 
@@ -62,7 +73,13 @@ class LiteLLMProvider(BaseLLMProvider):
 
     def _completion(self, messages: list[dict], **extra_kwargs) -> Any:
         """Call litellm.completion with standard kwargs."""
-        import litellm
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "litellm is required for the LiteLLM provider. "
+                "Install it with: pip install 'litellm>=1.83.0,<2.0'"
+            )
 
         kwargs: dict[str, Any] = {
             "model": self.model_name,
@@ -130,9 +147,15 @@ class LiteLLMProvider(BaseLLMProvider):
                 )
                 self._store_usage(response)
                 json_str = response.choices[0].message.content
+                if not json_str:
+                    raise ValueError("Empty response content from LiteLLM")
                 return schema.model_validate_json(json_str)
 
+            except ImportError:
+                raise
             except Exception as e:
+                if _is_non_retryable(e):
+                    raise RuntimeError(f"LiteLLM call failed: {e}") from e
                 last_err = e
                 if self.verbose:
                     print(f"  Error: {e}")
@@ -156,9 +179,16 @@ class LiteLLMProvider(BaseLLMProvider):
             try:
                 response = self._completion(messages)
                 self._store_usage(response)
-                return response.choices[0].message.content
+                content = response.choices[0].message.content
+                if content is None:
+                    raise ValueError("Empty response content from LiteLLM")
+                return content
 
+            except ImportError:
+                raise
             except Exception as e:
+                if _is_non_retryable(e):
+                    raise RuntimeError(f"LiteLLM raw call failed: {e}") from e
                 last_err = e
                 if attempt < self.retries - 1:
                     sleep_time = random.uniform(self.backoff_min, self.backoff_max)

--- a/llm/unified_client.py
+++ b/llm/unified_client.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from .anthropic_provider import AnthropicProvider
 from .deepseek_provider import DeepSeekProvider
 from .gemini_provider import GeminiProvider
+from .litellm_provider import LiteLLMProvider
 from .mock_provider import MockProvider
 from .openai_provider import OpenAIProvider
 from .token_tracker import get_token_tracker
@@ -32,7 +33,7 @@ class UnifiedLLMClient:
         The config now supports a 'provider' field for each model profile.
         If not specified, defaults to 'openai' for backward compatibility.
         
-        Available providers: openai, gemini, anthropic, xai
+        Available providers: openai, gemini, anthropic, xai, litellm
         
         Args:
             cfg: Configuration dictionary
@@ -119,6 +120,11 @@ class UnifiedLLMClient:
             )
         elif provider_name == "deepseek":
             self.provider = DeepSeekProvider(
+                **common_kwargs,
+                verbose=llm_verbose
+            )
+        elif provider_name == "litellm":
+            self.provider = LiteLLMProvider(
                 **common_kwargs,
                 verbose=llm_verbose
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ google-genai>=0.1.0
 anthropic>=0.3.0
 xai-sdk>=0.0.5
 tiktoken>=0.5.0
+litellm>=1.83.0,<2.0
 
 # CLI & Configuration  
 typer>=0.9.0

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,299 @@
+"""Tests for LiteLLM provider."""
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+from llm.litellm_provider import LiteLLMProvider, _is_non_retryable
+
+
+class SampleSchema(BaseModel):
+    answer: str
+    confidence: float
+
+
+def _make_provider(**overrides):
+    defaults = {
+        "config": {},
+        "model_name": "anthropic/claude-haiku-4-5",
+        "retries": 1,
+        "backoff_min": 0.0,
+        "backoff_max": 0.0,
+    }
+    defaults.update(overrides)
+    return LiteLLMProvider(**defaults)
+
+
+def _mock_response(content="Hello", prompt_tokens=10, completion_tokens=5):
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class TestLiteLLMProviderInit(unittest.TestCase):
+    def test_default_config(self):
+        p = _make_provider()
+        assert p.model_name == "anthropic/claude-haiku-4-5"
+        assert p.provider_name == "LiteLLM"
+        assert p.supports_thinking is False
+        assert p.api_key is None
+        assert p.api_base is None
+
+    def test_api_key_from_env(self):
+        with patch.dict("os.environ", {"LITELLM_API_KEY": "sk-test"}):
+            p = _make_provider()
+            assert p.api_key == "sk-test"
+
+    def test_custom_api_key_env(self):
+        with patch.dict("os.environ", {"MY_KEY": "sk-custom"}):
+            p = _make_provider(config={"litellm": {"api_key_env": "MY_KEY"}})
+            assert p.api_key == "sk-custom"
+
+    def test_api_base_from_config(self):
+        p = _make_provider(config={"litellm": {"api_base": "http://proxy:4000"}})
+        assert p.api_base == "http://proxy:4000"
+
+    def test_api_base_from_env(self):
+        with patch.dict("os.environ", {"LITELLM_API_BASE": "http://env-proxy:8000"}):
+            p = _make_provider()
+            assert p.api_base == "http://env-proxy:8000"
+
+
+class TestLiteLLMProviderRaw(unittest.TestCase):
+    def test_raw_success(self):
+        p = _make_provider()
+        mock_resp = _mock_response(content="The answer is 4")
+        with patch.object(p, "_completion", return_value=mock_resp) as mock_comp:
+            result = p.raw(system="You are helpful", user="What is 2+2?")
+            assert result == "The answer is 4"
+            mock_comp.assert_called_once()
+            args = mock_comp.call_args
+            messages = args[0][0]
+            assert messages[0]["role"] == "system"
+            assert messages[1]["role"] == "user"
+
+    def test_raw_none_content_raises(self):
+        p = _make_provider()
+        mock_resp = _mock_response(content=None)
+        with patch.object(p, "_completion", return_value=mock_resp):
+            with self.assertRaises(RuntimeError) as ctx:
+                p.raw(system="S", user="U")
+            assert "Empty response" in str(ctx.exception)
+
+    def test_raw_retries_on_transient_error(self):
+        p = _make_provider(retries=3, backoff_min=0, backoff_max=0)
+        call_count = 0
+
+        def _failing_then_success(messages, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("network blip")
+            return _mock_response(content="recovered")
+
+        with patch.object(p, "_completion", side_effect=_failing_then_success):
+            result = p.raw(system="S", user="U")
+            assert result == "recovered"
+            assert call_count == 3
+
+    def test_raw_no_retry_on_auth_error(self):
+        p = _make_provider(retries=3, backoff_min=0, backoff_max=0)
+
+        auth_exc = type("AuthenticationError", (Exception,), {
+            "__module__": "litellm.exceptions",
+            "__qualname__": "AuthenticationError",
+        })("Invalid API key")
+
+        with patch.object(p, "_completion", side_effect=auth_exc):
+            with self.assertRaises(RuntimeError) as ctx:
+                p.raw(system="S", user="U")
+            assert "Invalid API key" in str(ctx.exception)
+
+
+class TestLiteLLMProviderParse(unittest.TestCase):
+    def test_parse_success(self):
+        p = _make_provider()
+        json_content = '{"answer": "four", "confidence": 0.95}'
+        mock_resp = _mock_response(content=json_content)
+        with patch.object(p, "_completion", return_value=mock_resp) as mock_comp:
+            result = p.parse(system="Return JSON", user="What is 2+2?", schema=SampleSchema)
+            assert isinstance(result, SampleSchema)
+            assert result.answer == "four"
+            assert result.confidence == 0.95
+            call_kwargs = mock_comp.call_args
+            assert call_kwargs[1]["response_format"] == {"type": "json_object"}
+
+    def test_parse_none_content_raises(self):
+        p = _make_provider()
+        mock_resp = _mock_response(content=None)
+        with patch.object(p, "_completion", return_value=mock_resp):
+            with self.assertRaises(RuntimeError) as ctx:
+                p.parse(system="S", user="U", schema=SampleSchema)
+            assert "Empty response" in str(ctx.exception)
+
+    def test_parse_invalid_json_retries(self):
+        p = _make_provider(retries=2, backoff_min=0, backoff_max=0)
+        call_count = 0
+
+        def _bad_then_good(messages, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_response(content="not valid json{{{")
+            return _mock_response(content='{"answer": "ok", "confidence": 1.0}')
+
+        with patch.object(p, "_completion", side_effect=_bad_then_good):
+            result = p.parse(system="S", user="U", schema=SampleSchema)
+            assert result.answer == "ok"
+            assert call_count == 2
+
+    def test_parse_no_retry_on_not_found(self):
+        p = _make_provider(retries=3, backoff_min=0, backoff_max=0)
+
+        not_found = type("NotFoundError", (Exception,), {
+            "__module__": "litellm.exceptions",
+            "__qualname__": "NotFoundError",
+        })("Model not found: bad/model")
+
+        with patch.object(p, "_completion", side_effect=not_found):
+            with self.assertRaises(RuntimeError) as ctx:
+                p.parse(system="S", user="U", schema=SampleSchema)
+            assert "Model not found" in str(ctx.exception)
+
+
+class TestLiteLLMProviderTokenUsage(unittest.TestCase):
+    def test_token_usage_tracked(self):
+        p = _make_provider()
+        mock_resp = _mock_response(content="hi", prompt_tokens=100, completion_tokens=50)
+        with patch.object(p, "_completion", return_value=mock_resp):
+            p.raw(system="S", user="U")
+            usage = p.get_last_token_usage()
+            assert usage is not None
+            assert usage["input_tokens"] == 100
+            assert usage["output_tokens"] == 50
+            assert usage["total_tokens"] == 150
+
+    def test_token_usage_none_initially(self):
+        p = _make_provider()
+        assert p.get_last_token_usage() is None
+
+    def test_token_usage_survives_missing_usage(self):
+        p = _make_provider()
+        resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+        )
+        with patch.object(p, "_completion", return_value=resp):
+            p.raw(system="S", user="U")
+            assert p.get_last_token_usage() is None
+
+
+class TestLiteLLMProviderCompletion(unittest.TestCase):
+    def test_completion_passes_drop_params(self):
+        p = _make_provider()
+        fake_litellm = MagicMock()
+        fake_litellm.completion.return_value = _mock_response(content="ok")
+        with patch.dict(sys.modules, {"litellm": fake_litellm}):
+            p._completion([{"role": "user", "content": "hi"}])
+            call_kwargs = fake_litellm.completion.call_args[1]
+            assert call_kwargs["drop_params"] is True
+
+    def test_completion_passes_api_key_when_set(self):
+        p = _make_provider()
+        p.api_key = "sk-test-key"
+        fake_litellm = MagicMock()
+        fake_litellm.completion.return_value = _mock_response(content="ok")
+        with patch.dict(sys.modules, {"litellm": fake_litellm}):
+            p._completion([{"role": "user", "content": "hi"}])
+            call_kwargs = fake_litellm.completion.call_args[1]
+            assert call_kwargs["api_key"] == "sk-test-key"
+
+    def test_completion_omits_api_key_when_none(self):
+        p = _make_provider()
+        p.api_key = None
+        fake_litellm = MagicMock()
+        fake_litellm.completion.return_value = _mock_response(content="ok")
+        with patch.dict(sys.modules, {"litellm": fake_litellm}):
+            p._completion([{"role": "user", "content": "hi"}])
+            call_kwargs = fake_litellm.completion.call_args[1]
+            assert "api_key" not in call_kwargs
+
+    def test_completion_passes_api_base_when_set(self):
+        p = _make_provider()
+        p.api_base = "http://my-proxy:4000"
+        fake_litellm = MagicMock()
+        fake_litellm.completion.return_value = _mock_response(content="ok")
+        with patch.dict(sys.modules, {"litellm": fake_litellm}):
+            p._completion([{"role": "user", "content": "hi"}])
+            call_kwargs = fake_litellm.completion.call_args[1]
+            assert call_kwargs["api_base"] == "http://my-proxy:4000"
+
+    def test_import_error_message(self):
+        p = _make_provider()
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "litellm":
+                raise ImportError("No module named 'litellm'")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with self.assertRaises(ImportError) as ctx:
+                p._completion([{"role": "user", "content": "hi"}])
+            assert "pip install" in str(ctx.exception)
+
+
+class TestNonRetryableHelper(unittest.TestCase):
+    def test_auth_error_is_non_retryable(self):
+        exc = type("AuthenticationError", (Exception,), {
+            "__module__": "litellm.exceptions",
+            "__qualname__": "AuthenticationError",
+        })("bad key")
+        assert _is_non_retryable(exc) is True
+
+    def test_not_found_is_non_retryable(self):
+        exc = type("NotFoundError", (Exception,), {
+            "__module__": "litellm.exceptions",
+            "__qualname__": "NotFoundError",
+        })("model not found")
+        assert _is_non_retryable(exc) is True
+
+    def test_connection_error_is_retryable(self):
+        assert _is_non_retryable(ConnectionError("timeout")) is False
+
+    def test_generic_exception_is_retryable(self):
+        assert _is_non_retryable(RuntimeError("something broke")) is False
+
+    def test_rate_limit_is_retryable(self):
+        exc = type("RateLimitError", (Exception,), {
+            "__module__": "litellm.exceptions",
+            "__qualname__": "RateLimitError",
+        })("429")
+        assert _is_non_retryable(exc) is False
+
+
+class TestUnifiedClientLiteLLMRegistration(unittest.TestCase):
+    def test_litellm_provider_selected(self):
+        cfg = {"models": {"graph": {"provider": "litellm", "model": "anthropic/claude-haiku-4-5"}}}
+
+        class DummyLiteLLM:
+            provider_name = "LiteLLM"
+            supports_thinking = False
+            def __init__(self, **kw): pass
+            def raw(self, *, system, user): return "ok"
+
+        with patch("llm.unified_client.LiteLLMProvider", DummyLiteLLM):
+            from llm.unified_client import UnifiedLLMClient
+            uc = UnifiedLLMClient(cfg, profile="graph")
+            assert uc.provider.provider_name == "LiteLLM"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds LiteLLM as a new provider, giving Hound access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Together, Mistral, Cohere, and more) through [LiteLLM's](https://litellm.ai) unified interface
- No hardcoded models - works with any model string LiteLLM supports; users bring whatever models are on their gateway

## Changes

| File | Description |
|------|-------------|
| `llm/litellm_provider.py` | New `LiteLLMProvider` (211 lines) implementing `BaseLLMProvider` with `parse()` and `raw()` via `litellm.completion()` |
| `tests/test_litellm_provider.py` | 27 unit tests covering raw, parse, retries, auth errors, null content, token usage, drop_params, api_key forwarding, import error, provider registration |
| `llm/unified_client.py` | Registered `litellm` as a provider option in the unified client dispatch |
| `requirements.txt` | Added `litellm>=1.83.0,<2.0` |

## Design decisions

- **`drop_params=True` by default** - silently drops provider-unsupported kwargs (`seed`, `strict`, `presence_penalty`, etc.) so the same Hound workflow runs across providers without 400 errors
- **Smart retry** - transient errors (connection, rate limit, timeout) are retried with exponential backoff. Non-retryable errors (auth failure, model not found, bad request) fail immediately without wasting retry attempts
- **Null content guard** - raises `ValueError("Empty response content")` if the provider returns `None` content, instead of crashing downstream
- **ImportError guard** - clear install message if litellm isn't installed, instead of confusing retry-then-fail behavior
- **No hardcoded models** - model string is passed through as-is to `litellm.completion()`; available models depend on the user's LiteLLM config or provider API keys

## Tests

**1. Unit tests (27/27 pass):**
```
tests/test_litellm_provider.py::TestLiteLLMProviderInit::test_default_config PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderInit::test_api_key_from_env PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderInit::test_custom_api_key_env PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderInit::test_api_base_from_config PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderInit::test_api_base_from_env PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderRaw::test_raw_success PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderRaw::test_raw_none_content_raises PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderRaw::test_raw_retries_on_transient_error PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderRaw::test_raw_no_retry_on_auth_error PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderParse::test_parse_success PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderParse::test_parse_none_content_raises PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderParse::test_parse_invalid_json_retries PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderParse::test_parse_no_retry_on_not_found PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderTokenUsage::test_token_usage_tracked PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderTokenUsage::test_token_usage_none_initially PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderTokenUsage::test_token_usage_survives_missing_usage PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderCompletion::test_completion_passes_drop_params PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderCompletion::test_completion_passes_api_key_when_set PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderCompletion::test_completion_omits_api_key_when_none PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderCompletion::test_completion_passes_api_base_when_set PASSED
tests/test_litellm_provider.py::TestLiteLLMProviderCompletion::test_import_error_message PASSED
tests/test_litellm_provider.py::TestNonRetryableHelper::test_auth_error_is_non_retryable PASSED
tests/test_litellm_provider.py::TestNonRetryableHelper::test_not_found_is_non_retryable PASSED
tests/test_litellm_provider.py::TestNonRetryableHelper::test_connection_error_is_retryable PASSED
tests/test_litellm_provider.py::TestNonRetryableHelper::test_generic_exception_is_retryable PASSED
tests/test_litellm_provider.py::TestNonRetryableHelper::test_rate_limit_is_retryable PASSED
tests/test_litellm_provider.py::TestUnifiedClientLiteLLMRegistration::test_litellm_provider_selected PASSED
```

**2. Full regression suite (119/119 pass):**
```
$ python3 -m pytest tests/ -v
119 passed in 12.98s
```

**3. Live E2E via local LiteLLM proxy (localhost:4000):**
```
=== HOUND via local proxy ===
raw(): Tokyo
parse(): answer=63
tokens: {'input_tokens': 91, 'output_tokens': 9, 'total_tokens': 100}
HOUND PROXY PASSED
```
Full chain verified: `LiteLLMProvider` -> `litellm.completion()` -> LiteLLM proxy -> Azure Foundry -> response parsed back through Pydantic schema.

**4. Live E2E direct SDK call:**
```
=== HOUND E2E ===
raw(): 2+2 equals 4.
parse(): answer=56, explanation=7 multiplied by 8 equals 56.
HOUND E2E PASSED
```

## Risk / Compatibility

- Additive only - no existing providers modified
- Follows the same `BaseLLMProvider` pattern as OpenAI, Anthropic, Gemini, DeepSeek, and xAI providers
- Full regression suite passes with zero failures

## Example usage

Set `provider: litellm` in your config and point `model` to any model available on your LiteLLM setup. The model string is passed through to LiteLLM as-is - no restrictions on which provider or model you use.

```yaml
# config.yaml - use any model your LiteLLM setup supports
models:
  graph:
    provider: litellm
    model: <your-model>        # e.g. any model from `litellm --list-models`

# Optional: only needed for LiteLLM proxy deployments
litellm:
  api_base: http://localhost:4000
  api_key_env: LITELLM_API_KEY
```

```python
from llm.unified_client import UnifiedLLMClient
from pydantic import BaseModel

# Config-driven - model comes from yaml, not hardcoded
cfg = {
    "models": {
        "graph": {"provider": "litellm", "model": "anthropic/claude-sonnet-4-6"}
    }
}
client = UnifiedLLMClient(cfg=cfg, profile="graph")

# Plain text call
response = client.raw(
    system="You are a security auditor.",
    user="Summarize this contract's access control patterns."
)
print(response)

# Structured output with Pydantic schema
class Finding(BaseModel):
    severity: str
    description: str

finding = client.parse(
    system="You are a security auditor.",
    user="Analyze this function for vulnerabilities.",
    schema=Finding,
)
print(f"{finding.severity}: {finding.description}")
```

```bash
# Provider API keys are read from env vars automatically by LiteLLM
export ANTHROPIC_API_KEY="sk-..."
# Or for proxy deployments
export LITELLM_API_KEY="sk-proxy-key"
export LITELLM_API_BASE="http://localhost:4000"

python -m hound analyze <target>
```
